### PR TITLE
Add clerk login, persistence and OP:CLERK reporting

### DIFF
--- a/5ESS.pl
+++ b/5ESS.pl
@@ -192,6 +192,12 @@ sub rcaccess_allows_changes {
     return uc($mask) eq 'FFFFF';
 }
 
+sub clerk_allows_changes {
+    my ($session) = @_;
+    return 1 unless $session->{channel} =~ /^RCV_/;
+    return defined $session->{clerk_id} && $session->{clerk_id} ne '';
+}
+
 sub channel_allows_rc_changes {
     my ($session) = @_;
     return 0 if $session->{channel} eq 'SCC';
@@ -215,17 +221,50 @@ sub session_prompt {
 }
 
 sub session_create {
-    my ($channel) = @_;
+    my ($channel, $clerk_id) = @_;
     $session_seq++;
     return {
         session_id       => $session_seq,
         channel          => $channel,
         mode             => ($channel eq 'SCC') ? 'SCC' : 'CRAFT',
-        clerk_id         => undef,
+        clerk_id         => $clerk_id,
         tty_name         => 'ttyV',
         permissions_mask => $rcaccess{'ttyV'} // 'FFFFF',
         created_at       => now_stamp(),
     };
+}
+
+sub clerk_login {
+    my ($channel) = @_;
+    while (1) {
+        print "CLERK ID? ";
+        my $clerk_id = <STDIN> // '';
+        chomp $clerk_id;
+        $clerk_id =~ s/^\s+|\s+$//g;
+        next unless $clerk_id;
+
+        print "PASSWORD? ";
+        my $password = <STDIN> // '';
+        chomp $password;
+
+        if (exists $clerks{$clerk_id}) {
+            if ($clerks{$clerk_id} eq $password) {
+                return $clerk_id;
+            }
+            print "NG - INVALID PASSWORD\n";
+            next;
+        }
+
+        if ($channel eq 'TEST') {
+            $clerks{$clerk_id} = $password;
+            my $state = dmert_snapshot_state();
+            dmert_save_state($state, "clerk $clerk_id");
+            print "NEW CLERK CREATED\n";
+            return $clerk_id;
+        }
+
+        print "NG - CLERK NOT AUTHORIZED\n";
+    }
 }
 
 sub select_channel {
@@ -272,6 +311,12 @@ sub handle_set_rcaccess {
     print "RCACCESS UPDATED\n";
 }
 
+sub handle_op_clerk {
+    my ($session) = @_;
+    my $clerk = $session->{clerk_id} // 'NONE';
+    print "CLERK ID=\"$clerk\" CHANNEL=$session->{channel}\n";
+}
+
 sub dispatch_craft_command {
     my ($session, $cmd) = @_;
     if ($cmd =~ /^RCV:MENU:APPRC\b/i || $cmd =~ /^RCV\b/i) {
@@ -297,12 +342,16 @@ sub dispatch_craft_command {
         handle_op_rcaccess($1);
         return 1;
     }
+    if ($cmd =~ /^OP:CLERK\s*;?$/i) {
+        handle_op_clerk($session);
+        return 1;
+    }
     if ($cmd =~ /^SET:RCACCESS,TTY="([^"]+)",ACCESS=H'([0-9A-Fa-f]{5})'\s*;?$/i) {
         handle_set_rcaccess($1, $2);
         return 1;
     }
     if ($cmd =~ /^HELP$/i) {
-        print "\nAvailable commands: RCV:MENU:APPRC   ALM:LIST   MCC:GUIDE   MCC:SHOW <page>   OP:RCACCESS   SET:RCACCESS   HELP   QUIT\n";
+        print "\nAvailable commands: RCV:MENU:APPRC   ALM:LIST   MCC:GUIDE   MCC:SHOW <page>   OP:CLERK   OP:RCACCESS   SET:RCACCESS   HELP   QUIT\n";
         return 1;
     }
     print "? Unrecognised command – type HELP for options.\n";
@@ -312,6 +361,7 @@ sub dispatch_craft_command {
 sub line_station_menu {
     my ($session) = @_;
     return unless allow_or_deny(channel_allows_rc_changes($session), 'CHANNEL RESTRICTED');
+    return unless allow_or_deny(clerk_allows_changes($session), 'CLERK LOGIN REQUIRED');
     return unless allow_or_deny(rcaccess_allows_changes($session), 'RCACCESS DENIED');
 
     print "\n[1.11] Line Assignment – Terminal #, Cable-Pair, COS, Type, Class, Features\n";
@@ -353,6 +403,7 @@ sub line_station_menu {
 sub directory_number_menu {
     my ($session) = @_;
     return unless allow_or_deny(channel_allows_rc_changes($session), 'CHANNEL RESTRICTED');
+    return unless allow_or_deny(clerk_allows_changes($session), 'CLERK LOGIN REQUIRED');
     return unless allow_or_deny(rcaccess_allows_changes($session), 'RCACCESS DENIED');
 
     print "\n[8.12] Assign Directory Number – enter DN & Terminal #\n";
@@ -419,6 +470,10 @@ sub dispatch_rcv_menu {
     }
     if ($cmd =~ /^OP:RCACCESS,TTY="([^"]+)"\s*;?$/i) {
         handle_op_rcaccess($1);
+        return 1;
+    }
+    if ($cmd =~ /^OP:CLERK\s*;?$/i) {
+        handle_op_clerk($session);
         return 1;
     }
     if ($cmd =~ /^SET:RCACCESS,TTY="([^"]+)",ACCESS=H'([0-9A-Fa-f]{5})'\s*;?$/i) {
@@ -496,7 +551,8 @@ my $state = dmert_load_state();
 @scc_events = @{ $state->{scc_log} // [] };
 
 my $channel = select_channel();
-my $session = session_create($channel);
+my $clerk_id = clerk_login($channel);
+my $session = session_create($channel, $clerk_id);
 
 print "\n* * *  5ESS Craft Shell (sim)  * * *\nType HELP for command list.\n\n";
 

--- a/README
+++ b/README
@@ -33,8 +33,8 @@ STARTUP FLOW
 3. In-memory structures are populated from the loaded state
    It assigns the loaded hashes/arrays into %lines, %dns, @alarms, %rcaccess, %clerks, @batch_queue, @scc_events. 
 
-4. Channel is selected, and a session is created
-   You pick a channel from the menu; default is RC/V Local. A session object is created with channel + mode + metadata.  
+4. Channel is selected, clerk login is prompted, and a session is created
+   You pick a channel from the menu; default is RC/V Local. You then enter CLERK ID and PASSWORD. Existing clerks must match the stored password; new clerk creation is only allowed when the channel is TEST. The session object is created with channel + mode + metadata.  
 
 5. It prints the “Craft Shell (sim)” banner and enters the main loop 
 
@@ -73,7 +73,7 @@ Session object fields (created fresh each run):
 * session_id (increments)
 * channel
 * mode: “SCC” if channel==SCC, otherwise “CRAFT”
-* clerk_id (unused right now)
+* clerk_id (set during login)
 * tty_name (defaults to ttyV)
 * permissions_mask (copied from rcaccess{ttyV})
 * created_at 
@@ -121,7 +121,11 @@ There are two gates checked before RC/V “changes” (Line/Station, DN assignme
 * If the session channel is SCC, RC changes are blocked (“NG - CHANNEL RESTRICTED”). 
 * Otherwise allowed. 
 
-2. RCACCESS restriction (only applied for RC/V channels)
+2. Clerk login restriction (only applied for RC/V channels)
+
+* If session channel begins with RCV_ then a clerk must be logged in, otherwise “NG - CLERK LOGIN REQUIRED”.  
+
+3. RCACCESS restriction (only applied for RC/V channels)
 
 * If session channel begins with RCV_ then it checks rcaccess{tty_name}; only mask == FFFFF is allowed. Otherwise “NG - RCACCESS DENIED”.  
 
@@ -144,6 +148,8 @@ Accepted commands:
   Displays a stub page body from %mcc_pages (or “? MCC page not found”).  
 * OP:RCACCESS,TTY="<tty>";
   Prints RCACCESS line if known, else “RL - NO SUCH TTY”.  
+* OP:CLERK;
+  Prints the current clerk ID and channel.  
 * SET:RCACCESS,TTY="<tty>",ACCESS=H'<mask>';
   Updates rcaccess, saves state, enqueues an SCC log event, prints “RCACCESS UPDATED”.  
 * HELP
@@ -164,7 +170,7 @@ Accepted inputs:
   Prints a “Translation Database Dump” listing each terminal record with DN/COS/TYPE/CLASS/FEAT/CABLE. 
 * Q or RCV:MENU:SH!
   Exits RC/V menu back to craft shell. 
-* ALM:LIST, OP:RCACCESS…, SET:RCACCESS…
+* ALM:LIST, OP:CLERK…, OP:RCACCESS…, SET:RCACCESS…
   Those work in RC/V mode too (same behaviour as craft shell). 
 
 Any other input:


### PR DESCRIPTION
### Motivation

- Require and record a clerk identity for RC/V change operations to better model operational access control. 
- Allow new clerk provisioning in `TEST` channel and persist clerk credentials in the emulator state. 
- Expose the current clerk identity via an OP command for visibility during sessions. 
- Update documentation to reflect the startup/login flow and new command.

### Description

- Added a `clerk_login` flow and call at startup after `select_channel()` so the chosen clerk ID is stored on the session via `session_create($channel, $clerk_id)` and placed into `$session->{clerk_id}`. 
- Implemented `clerk_allows_changes` and enforced it in `line_station_menu` and `directory_number_menu` so RC/V changes require a logged-in clerk for `RCV_` channels. 
- Added `handle_op_clerk` and wired `OP:CLERK;` handling into `dispatch_craft_command` and `dispatch_rcv_menu` to return `CLERK ID` and `CHANNEL`. 
- Persisted new clerks using the existing `dmert_snapshot_state()` / `dmert_save_state()` calls and updated `README` to document the login step and `OP:CLERK` command; changes are in `5ESS.pl` and `README`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964cb7c5464832ab4a32a9bd285dd83)