### PR TITLE
Fix env var lookup in Persist::base_dir

### DIFF
--- a/lib/Persist.pm
+++ b/lib/Persist.pm
@@ -12,7 +12,7 @@ sub now_stamp {
 }
 
 sub base_dir {
-    return $ENV{5ESS_STATE_DIR} || $ENV{5ESS_VAR} || './var';
+    return $ENV{'5ESS_STATE_DIR'} || $ENV{'5ESS_VAR'} || './var';
 }
 
 sub journal_path {


### PR DESCRIPTION
### Motivation
- Prevent Perl bareword parsing errors caused by numeric-leading environment variable keys that made the program fail to compile.
- Ensure the persistence base directory lookup reads `%ENV` keys safely on platforms where `5ESS_STATE_DIR` or `5ESS_VAR` are set.

### Description
- Quote numeric-leading environment keys in `lib/Persist.pm` by changing `$ENV{5ESS_STATE_DIR}` to `$ENV{'5ESS_STATE_DIR'}`.
- Update is localized to `Persist::base_dir` so it now returns `$ENV{'5ESS_STATE_DIR'} || $ENV{'5ESS_VAR'} || './var'`.
- No other functional changes were introduced.