### PR TITLE
Fix startup warnings in TermUI and session/env handling in 5ESS.pl

### DIFF
--- a/5ESS.pl
+++ b/5ESS.pl
@@ -41,7 +41,7 @@ my %config = (
     auth_uses              => 5,
 );
 
-srand($ENV{5ESS_SEED}) if defined $ENV{5ESS_SEED};
+srand($ENV{'5ESS_SEED'}) if defined $ENV{'5ESS_SEED'};
 
 my $ui = TermUI->new(title => 'PACIFIC BELL 5ESS CRAFT ENVIRONMENT');
 
@@ -471,6 +471,7 @@ sub handle_op_clerk {
 }
 
 sub handle_mcc_guide {
+    my ($session) = @_;
     print "\n--- MCC PAGE LOCATION GUIDE (STUB) ---\n";
     print "USE MCC:SHOW <PAGE> TO DISPLAY A PAGE.\n";
     print "KNOWN PAGES: 1000, 105, 110\n";

--- a/lib/TermUI.pm
+++ b/lib/TermUI.pm
@@ -44,13 +44,13 @@ sub draw_header {
     my $line = sprintf("%-*s", $self->{cols}, $title);
     $line =~ s/\s+$//;
     print "$line\n";
-    print ("-" x $self->{cols}) . "\n";
+    print(("-" x $self->{cols}) . "\n");
 }
 
 sub draw_footer {
     my ($self, $text) = @_;
     $text ||= '';
-    print ("-" x $self->{cols}) . "\n";
+    print(("-" x $self->{cols}) . "\n");
     print "$text\n" if $text ne '';
 }
 


### PR DESCRIPTION
### Motivation
- Suppress Perl startup warnings caused by ambiguous `print` syntax in `lib/TermUI.pm`.
- Avoid bareword interpretation for the `5ESS_SEED` environment key by quoting the hash key.
- Ensure `handle_mcc_guide` receives the session argument to prevent use of an undeclared `$session`.
- Restore clean interpreter startup so the emulator can compile and run without immediate errors.

### Description
- Updated `lib/TermUI.pm` to wrap the separator expression in `print( ... )` to force expression context for the `("-" x $self->{cols}) . "\n"` output in both header and footer draws.
- Changed `srand($ENV{5ESS_SEED})` to `srand($ENV{'5ESS_SEED'})` in `5ESS.pl` to prevent bareword parsing of the environment key.
- Added `my ($session) = @_;` to `sub handle_mcc_guide` in `5ESS.pl` so `result_ok($session, ...)` is called with a declared variable.