### PR TITLE
Add ROP stream, simulator config, PacBell MOTD templating, and poke 196

### DIFF
--- a/README
+++ b/README
@@ -40,6 +40,14 @@ Deterministic SCC scheduling (tests/dev):
 
   export 5ESS_SEED=1
 
+Config (feature flags, theming, pokes, ROP):
+
+  etc/sim.json
+
+Optional fixed timestamps for tests/dev:
+
+  export FIXED_TIME_FOR_TESTS=1995-06-15T12:34:56
+
 Resetting state:
 
   rm -rf ./var
@@ -49,6 +57,7 @@ DEV UTILITIES
 * /rclog [N]  - show last N journal entries
 * /save       - write a snapshot to var/state.json
 * /reload     - replay journal into memory
+* SHOW:ROP;   - show last 20 lines from the Records Output Printer (ROP)
 
 SMOKE TEST
 

--- a/docs/terminal-realism.md
+++ b/docs/terminal-realism.md
@@ -1,0 +1,48 @@
+# Terminal Realism (Pacific Bell Theme)
+
+## Terminal archetypes and channels
+
+Channels map to terminal archetypes and default TTYs:
+
+| Channel     | Terminal Type | Default TTY |
+|-------------|---------------|-------------|
+| MCC         | MCC           | ttyV        |
+| RCV_LOCAL   | RCV_LOCAL     | ttyV        |
+| RCV_REMOTE  | RCV_REMOTE    | ttyW        |
+| SCC         | SCC           | ttyS        |
+| TEST        | TEST          | ttyT        |
+
+TTY defaults are configurable via `etc/sim.json` under `terminal_map`.
+
+## Poke dispatcher
+
+When `FEATURE_POKES=1`, numeric input at the `CMD<` prompt is treated as a poke. The
+default table includes poke **196** to enter RC/V. Poke behavior is defined in
+`etc/sim.json` under `pokes`.
+
+On success, the emulator logs STARTING/COMPLETED entries to the ROP stream. On
+denial (channel/login/RCACCESS), it prints `RESULT: NG - RC SECURITY DENIED` and
+logs the denial.
+
+## RC/V menu flow (compatibility)
+
+Poke 196 is an alias for entering the existing RC/V menu when
+`FEATURE_RCV_VIEWS=0`. The current flow remains:
+
+* 1 — Line/Station assignment
+* 8 — Directory Number assignment
+* 0 — Verify (translation dump)
+* Q — Quit back to craft shell
+
+## Records Output Printer (ROP)
+
+ROP is a separate append-only stream stored under the state directory, default
+`var/rop.log`. Each line uses a deterministic, paper-style format:
+
+```
+YYYY-MM-DD HH:MM:SS  BRAND/OFFICE SWITCH  ROP  SUBSYS SEV  message [key=value...]
+```
+
+ROP is viewable via `SHOW:ROP;` (default 20 lines) or
+`SHOW:ROP,LINES=50;`.
+

--- a/etc/motd.dat
+++ b/etc/motd.dat
@@ -1,19 +1,16 @@
 ************************************************************************
 *                                                                      *
-*      AT&T/LUCENT TECHNOLOGIES 5ESS® SWITCHING SYSTEM                 *
-*                                                                      *
 *      PACIFIC BELL TELEPHONE COMPANY                                  *
+*      NETWORK OPERATIONS / CENTRAL OFFICE SYSTEMS                     *
 *                                                                      *
-*      SYSTEM:   PB-5E-LA12                                            *
-*      LOCATION: TEST LOCATION                                         *
-*      GENERIC:  PL0.1                                                 *
+*  THIS IS A PRIVATE SYSTEM RESTRICTED TO AUTHORIZED USE ONLY.         *
+*  ALL ACTIVITY MAY BE MONITORED AND RECORDED.                         *
+*  UNAUTHORIZED ACCESS OR USE IS PROHIBITED AND SUBJECT TO             *
+*  DISCIPLINE AND PROSECUTION.                                         *
 *                                                                      *
-*  WARNING:                                                            *  
-*  This system is for the exclusive use of authorized personnel.       *
-*  Unauthorized access, use, or modification is prohibited and         *
-*  may be subject to criminal prosecution under applicable law.        *
-*                                                                      *
-*  ALL USAGE MAY BE MONITORED AND RECORDED.                            *
+*  OFFICE:   {{OFFICE_ID}}                                             *
+*  SWITCH:   {{SWITCH_NAME}}                                           *
+*  TTY:      {{TTY}}                                                   *
+*  DATE:     {{DATE}}  TIME: {{TIME}}                                  *
 *                                                                      *
 ************************************************************************
-

--- a/etc/sim.json
+++ b/etc/sim.json
@@ -1,0 +1,28 @@
+{
+  "feature_flags": {
+    "FEATURE_POKES": 1,
+    "FEATURE_ROP": 1,
+    "FEATURE_RCV_VIEWS": 0,
+    "FEATURE_RCV_BATCH": 0,
+    "FEATURE_SCC_STREAM": 1,
+    "FEATURE_REAPPLY_RC": 0
+  },
+  "theme": {
+    "brand": "Pacific Bell",
+    "office_id": "SF01",
+    "switch_name": "5ESS-SF"
+  },
+  "scc": {
+    "verbosity": "normal"
+  },
+  "pokes": {
+    "196": "RCV"
+  },
+  "rop": {
+    "file": "rop.log"
+  },
+  "rclog": {
+    "dir": "rclog"
+  },
+  "fixed_time_for_tests": ""
+}

--- a/lib/Persist.pm
+++ b/lib/Persist.pm
@@ -6,6 +6,13 @@ use JSON::PP;
 use File::Path qw(make_path);
 
 sub now_stamp {
+    if ($ENV{'FIXED_TIME_FOR_TESTS'}) {
+        my $fixed = $ENV{'FIXED_TIME_FOR_TESTS'};
+        if ($fixed =~ /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})$/) {
+            return sprintf "%04d-%02d-%02d %02d:%02d:%02d",
+                $1, $2, $3, $4, $5, $6;
+        }
+    }
     my @t = localtime();
     return sprintf "%04d-%02d-%02d %02d:%02d:%02d",
         $t[5] + 1900, $t[4] + 1, $t[3], $t[2], $t[1], $t[0];

--- a/lib/ROP.pm
+++ b/lib/ROP.pm
@@ -1,0 +1,74 @@
+package ROP;
+
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use Persist;
+
+sub new {
+    my ($class, %opts) = @_;
+    my $state_dir = $opts{state_dir} || Persist::base_dir();
+    my $path = $opts{path} || "$state_dir/rop.log";
+    my $self = {
+        state_dir   => $state_dir,
+        path        => $path,
+        brand       => $opts{brand} // 'AT&T/Lucent 5ESS Craft',
+        office_id   => $opts{office_id} // 'CO',
+        switch_name => $opts{switch_name} // '5ESS',
+    };
+    return bless $self, $class;
+}
+
+sub path {
+    my ($self) = @_;
+    return $self->{path};
+}
+
+sub _ensure_dir {
+    my ($self) = @_;
+    make_path($self->{state_dir}) unless -d $self->{state_dir};
+}
+
+sub log {
+    my ($self, $subsystem, $severity, $message, $meta) = @_;
+    $self->_ensure_dir();
+    my $stamp = Persist::now_stamp();
+    my $brand = $self->{brand};
+    my $office = $self->{office_id};
+    my $switch = $self->{switch_name};
+    my $line = sprintf(
+        "%s  %s/%s %s  ROP  %s %s  %s",
+        $stamp,
+        $brand,
+        $office,
+        $switch,
+        ($subsystem // 'SYS'),
+        ($severity // 'INFO'),
+        ($message // ''),
+    );
+    if ($meta && ref $meta eq 'HASH' && keys %{$meta}) {
+        my @pairs;
+        for my $key (sort keys %{$meta}) {
+            my $value = defined $meta->{$key} ? $meta->{$key} : '';
+            $value =~ s/\s+/ /g;
+            push @pairs, "$key=$value";
+        }
+        $line .= " [" . join(' ', @pairs) . "]";
+    }
+    open my $fh, '>>', $self->{path} or return;
+    print {$fh} $line . "\n";
+    close $fh;
+}
+
+sub tail {
+    my ($self, $count) = @_;
+    $count ||= 20;
+    return [] unless -e $self->{path};
+    open my $fh, '<', $self->{path} or return [];
+    my @lines = <$fh>;
+    close $fh;
+    return \@lines if @lines <= $count;
+    return [ @lines[-$count .. -1] ];
+}
+
+1;

--- a/lib/TermUI.pm
+++ b/lib/TermUI.pm
@@ -95,4 +95,16 @@ sub draw_status_line {
     }
 }
 
+sub render_template {
+    my ($self, $path, $vars) = @_;
+    return '' unless $path && -e $path;
+    open my $fh, '<', $path or return '';
+    local $/;
+    my $text = <$fh>;
+    close $fh;
+    $vars ||= {};
+    $text =~ s/\{\{(\w+)\}\}/exists $vars->{$1} ? $vars->{$1} : ''/ge;
+    return $text;
+}
+
 1;

--- a/man/5ess.1
+++ b/man/5ess.1
@@ -79,6 +79,11 @@ Show batch queue counts and recent jobs.
 Show job output.
 .SS Utilities
 .TP
+.B SHOW:ROP;
+Show the last 20 Records Output Printer lines (ROP). Use
+.BR SHOW:ROP,LINES=50;
+to change the count.
+.TP
 .B /rclog [N]
 Show the last N DMERT journal entries.
 .TP
@@ -89,8 +94,14 @@ Write a JSON snapshot of state.
 Reload state by replaying the journal.
 .SH FILES
 .TP
+.I etc/sim.json
+Configuration file for feature flags, theme, pokes, and ROP output.
+.TP
 .I etc/motd.dat
 Message of the day displayed at login.
+.TP
+.I var/rop.log
+Records Output Printer stream (when enabled).
 .TP
 .I var/dmert.journal
 Append-only journal file used for persistence.
@@ -104,5 +115,8 @@ Override the state directory (default: ./var).
 .TP
 .B 5ESS_SEED
 Seed RNG for deterministic SCC scheduling.
+.TP
+.B FIXED_TIME_FOR_TESTS
+Force deterministic timestamps, e.g. 1995-06-15T12:34:56.
 .SH AUTHOR
 C Jervis and contributors.


### PR DESCRIPTION
### Motivation

- Provide a separate Records Output Printer (ROP) stream for audit-style, human‑readable printer output and to surface RC/SCC/security events outside the existing SCC ring buffer.  
- Introduce a JSON-driven simulator configuration to enable feature flags (pokes, ROP, views, etc.), theming (Pacific Bell), and deterministic test timestamps.  
- Improve the login banner and MOTD to support Pacific Bell circa‑1995 theming with token expansion.  
- Add a numeric poke dispatcher (notably poke `196`) as a natural alias to enter the RC/V menu and to log the poke lifecycle to ROP.

### Description

- Added a new `lib/ROP.pm` module implementing `new`, `log`, `tail`, and `path` and appending deterministic ROP lines to `state_dir/rop.log`.  
- Added `etc/sim.json` for simulator defaults and feature flags and wired config loading + merge into `5ESS.pl` (kept default behaviour compatible).  
- Integrated ROP into `5ESS.pl` so security and RC events log to ROP (examples: `SET:RCACCESS`, IM line/DN assignments, `RCV COMMIT`) and implemented `SHOW:ROP;` / `SHOW:ROP,LINES=n;` to view the tail.  
- Added MOTD templating via `lib/TermUI.pm::render_template` and updated `etc/motd.dat` to a Pacific Bell themed template with tokens (`{{OFFICE_ID}}`, `{{SWITCH_NAME}}`, `{{TTY}}`, `{{DATE}}`, `{{TIME}}`), plus small session/terminal mapping and poke dispatch integration (numeric input handling, default poke `196`).