### PR TITLE
Add project docs and core tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
 .DS_Store
 var/
+
+# local switch state
+*.journal
+*.log
+*.tmp
+*.bak
+*.old
+
+# Perl build/test by-products
+blib/
+pm_to_blib
+Makefile
+Makefile.old
+MYMETA.*
+cover_db/
+nytprof.out
+
+# editor noise
+*~
+.#*

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,11 @@
+Revision history for 5ESS-EMU
+=============================
+
+Unreleased
+----------
+
+* Expanded repository hygiene files.
+* Added installation and maintainer documentation.
+* Added initial tests for core modules.
+* Added research and Pacific Bell theme notes.
+

--- a/HACKING
+++ b/HACKING
@@ -1,0 +1,76 @@
+Hacking on 5ESS-EMU
+===================
+
+5ESS-EMU should be developed like a small old-school Perl project: simple
+files, plain code, careful changes and useful tests.
+
+Working rules
+-------------
+
+* Do not work directly on `main`.
+* Make one coherent change at a time.
+* Prefer small commits with direct messages.
+* Keep the terminal craft-shell feel.
+* Do not introduce a modern web framework.
+* Do not commit generated state under `var/`.
+* Add or update tests for behavioural changes.
+* Keep third-party historical material separate from original source code.
+
+Suggested branch names
+----------------------
+
+    work/add-test-suite
+    work/refactor-persist
+    work/cgi-console
+    work/rcv-validation
+    work/docs-install
+
+Commit message style
+--------------------
+
+Use plain, descriptive commit messages:
+
+    Add regression tests for RC/V tickets
+
+    Cover ticket open, staged changes, validation failure and successful
+    commit. Use a temporary state directory so tests do not touch the
+    developer's working var tree.
+
+Avoid corporate or tool-flavoured commit messages. The project should read as
+a sincere maintainer's work, not as generated marketing copy.
+
+Testing
+-------
+
+Before committing, run:
+
+    perl -c 5ESS.pl
+    perl -Ilib -c lib/*.pm
+    prove -Ilib t
+
+If a test would be too awkward for a particular change, mention that in the
+commit message or in the relevant documentation.
+
+Refactoring
+-----------
+
+Refactor gradually. The current main script should shrink over time, but only
+behind tests. Move behaviour into modules without changing command output
+unless the command output is deliberately being corrected.
+
+Good future module targets include:
+
+    lib/FiveESS/Config.pm
+    lib/FiveESS/State.pm
+    lib/FiveESS/Command.pm
+    lib/FiveESS/Session.pm
+    lib/FiveESS/Craft.pm
+    lib/FiveESS/CGI.pm
+
+Historical material
+-------------------
+
+Research is encouraged, but cite it in project notes. Do not copy long manual
+passages into the source tree. Convert research into simulator behaviour,
+implementation notes, command references and clearly marked fictional demo
+data.

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,64 @@
+Installing 5ESS-EMU
+===================
+
+Requirements
+------------
+
+5ESS-EMU is written for Perl 5.
+
+The current code uses ordinary Perl modules:
+
+    strict
+    warnings
+    FindBin
+    Digest::SHA
+    JSON::PP
+    Term::ReadKey
+    Time::HiRes
+    File::Path
+    File::Temp      (tests)
+    Test::More      (tests)
+
+`Term::ReadKey` may need to be installed separately on some systems.
+
+Basic check
+-----------
+
+From the repository root:
+
+    perl -c 5ESS.pl
+    perl -Ilib -c lib/*.pm
+
+Run tests
+---------
+
+    prove -Ilib t
+
+or:
+
+    perl Makefile.PL
+    make test
+
+State directory
+---------------
+
+The simulator writes local state under `./var` unless told otherwise.
+
+For ordinary use:
+
+    perl 5ESS.pl
+
+For a disposable state tree:
+
+    mkdir -p /tmp/5ess-state
+    5ESS_STATE_DIR=/tmp/5ess-state perl 5ESS.pl
+
+Do not commit generated state, journals or logs.
+
+CGI notes
+---------
+
+The CGI interface is planned but should not be treated as complete until the
+terminal core has tests and reusable command/state modules. When added, the
+CGI interface should run under a conventional CGI-capable web server and use an
+explicit writable state directory.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME      => 'FiveESS-EMU',
+    VERSION   => '0.01',
+    PREREQ_PM => {
+        'JSON::PP'      => 0,
+        'Digest::SHA'   => 0,
+        'Time::HiRes'   => 0,
+        'Term::ReadKey' => 0,
+        'File::Path'    => 0,
+        'File::Temp'    => 0,
+        'Test::More'    => 0,
+    },
+    test => { TESTS => 't/*.t' },
+);

--- a/TODO
+++ b/TODO
@@ -1,0 +1,40 @@
+5ESS-EMU TODO
+=============
+
+Short term
+----------
+
+* Keep the test suite passing under `prove -Ilib t`.
+* Add a bootstrap/offline clerk provisioning tool.
+* Move configuration loading out of `5ESS.pl`.
+* Move command parsing into a testable module.
+* Document the current command set.
+* Add example terminal transcripts.
+* Add a deterministic demo office profile.
+
+Medium term
+-----------
+
+* Expand MCC page coverage.
+* Add a richer alarm catalogue.
+* Add trunk-group and line-equipment displays.
+* Add better RC/V validation and guided workflows.
+* Add ROP categories and operator event records.
+* Add journal integrity checks and compaction.
+* Add a simple CGI craft-console interface.
+
+Long term
+---------
+
+* Create a releasable tarball target.
+* Add a man page.
+* Add a polished Pacific Bell demo profile.
+* Add period-styled operator documentation.
+* Tag a first release once tests, docs and demo mode are coherent.
+
+Research
+--------
+
+* Build a research index for 5ESS documents and telecom history sources.
+* Separate official documentation, secondary reporting, lore and atmosphere.
+* Turn source research into implementation notes, not copied manual text.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,70 @@
+# Command reference
+
+This is an initial reference for the current terminal craft shell. It should be
+expanded as command parsing is moved into testable modules.
+
+Commands are simulator commands unless a later implementation note identifies a
+specific historical source.
+
+## Session
+
+| Command | Purpose |
+| --- | --- |
+| `HELP` | Show the short command list. |
+| `QUIT` | End the current craft-shell session. |
+| `/save` | Save a state snapshot. |
+| `/reload` | Rebuild state from the journal. |
+| `/rclog [n]` | Show recent journal lines. |
+
+## Alarms
+
+| Command | Purpose |
+| --- | --- |
+| `ALM:LIST;` | List active alarms. |
+| `ALM:ACK,<id>;` | Acknowledge an alarm. |
+| `ALM:CLEAR,<id>;` | Clear an alarm. |
+| `ALM:RAISE,<sev>,<source>,<text>;` | Raise a simulated alarm where permitted. |
+
+## MCC
+
+| Command | Purpose |
+| --- | --- |
+| `MCC:GUIDE;` | Display a short MCC guide. |
+| `MCC:SHOW <page>;` | Display a simulated MCC page. |
+
+## Operator and access
+
+| Command | Purpose |
+| --- | --- |
+| `OP:CLERK;` | Display current clerk/channel information. |
+| `OP:RCACCESS,TTY="ttyV";` | Display access mask for a TTY. |
+| `SET:RCACCESS,TTY="ttyV",ACCESS=H'FFFFF';` | Set simulated access mask where permitted. |
+| `REQ:AUTH,CLRK="CLERK";` | Request second-clerk authorisation. |
+
+## RC/V
+
+| Command | Purpose |
+| --- | --- |
+| `RCV:MENU:APPRC` | Enter the RC/V menu. |
+| `RCV:OPEN,TKT="ticket";` | Open a recent-change ticket. |
+| `RCV:ADD,FIELD=value;` | Stage a change on the open ticket. |
+| `RCV:CHECK;` | Validate staged changes. |
+| `RCV:COMMIT;` | Commit staged changes where permitted. |
+| `RCV:ABORT;` | Abort the open ticket. |
+
+Known staged fields include `TERM`, `DN`, `PAIR`, `COS`, `LINETYPE`, `CLASS`
+and `FEATURES`.
+
+## SCC
+
+| Command | Purpose |
+| --- | --- |
+| `SCC:SUBMIT,JOB="name",PARM="value";` | Submit a simulated SCC job. |
+| `SCC:STAT;` | Show SCC job counts and recent jobs. |
+| `SCC:OUT,JOBID=<id>;` | Show job output. |
+
+## ROP
+
+| Command | Purpose |
+| --- | --- |
+| `SHOW:ROP,LINES=n;` | Show the last `n` ROP records. |

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -1,0 +1,62 @@
+# Implementation notes
+
+This file records why simulator features exist and how closely they are tied
+to source material.
+
+Use these labels:
+
+* DOCUMENTED - based on identifiable technical documentation.
+* PLAUSIBLE - inferred from related systems or operating practice.
+* FICTIONAL - invented for the simulator.
+* ATMOSPHERIC - included for period flavour only.
+
+## Current simulator choices
+
+### Pacific Bell default theme
+
+Label: ATMOSPHERIC / PLAUSIBLE
+
+The default configuration uses Pacific Bell-flavoured names and a fictional
+Northern California office. This gives the simulator a coherent setting while
+remaining clearly separate from real telephone-company systems.
+
+### Journal-backed state
+
+Label: PLAUSIBLE
+
+The simulator keeps a simple append-only journal and replay mechanism. This is
+not a claim about actual 5ESS persistence internals. It gives the toy simulator
+an operator-friendly audit trail and makes later test/demo work predictable.
+
+### RC/V ticket workflow
+
+Label: PLAUSIBLE
+
+Recent-change/verify work is represented through open, staged changes, check,
+commit and abort. The exact command strings are simulator commands unless
+separately documented from source material.
+
+### ROP output
+
+Label: PLAUSIBLE / ATMOSPHERIC
+
+ROP output is implemented as a text log with terse records. It is intended to
+suggest printer/log output from a switching operations environment, not to
+reproduce a proprietary format exactly.
+
+### SCC jobs
+
+Label: PLAUSIBLE / FICTIONAL
+
+SCC jobs are represented as queued, running and done tasks. This creates
+background life in the simulator and a useful basis for future batch-style
+operations.
+
+## Future notes to add
+
+* MCC page model and page numbering.
+* Alarm catalogue and severity rules.
+* Trunk group representation.
+* Line equipment records.
+* CGI craft-console session model.
+* Demo office generation.

--- a/docs/pacific-bell-theme.md
+++ b/docs/pacific-bell-theme.md
@@ -1,0 +1,57 @@
+# Pacific Bell theme
+
+Pacific Bell is the default house style for 5ESS-EMU. The simulator should
+feel like a small central-office craft environment somewhere in California in
+the mid-1990s: terse terminals, ROP output, operator notices, service orders,
+SCC chatter and a large switching machine implied behind the screen.
+
+This is a simulated setting. Do not use real customer data or real internal
+company records.
+
+## Default fictional office
+
+| Field | Value |
+| --- | --- |
+| Company | Pacific Bell Telephone Company |
+| Region | Northern California |
+| Office id | SF01 |
+| Switch | 5ESS-SF |
+| Era | 1993-1998 |
+| Environment | Central office craft shell / network operations terminal |
+
+## Desired feel
+
+The project should feel like a recovered Unix account from a central office,
+not a modern dashboard. Favour fixed-width output, simple files, uppercase
+operator messages, short error codes, pager prompts and practical docs.
+
+Good atmosphere:
+
+* private-system warning banners;
+* clerk and TTY terminology;
+* RC/V tickets and terse result lines;
+* SCC jobs that complete asynchronously;
+* ROP printer-style records;
+* MCC page indexes and status summaries;
+* simulated alarms for power, modules, trunks, journals and operator actions;
+* configuration profiles for different fictional offices.
+
+Avoid:
+
+* cyberpunk excess;
+* modern SaaS language;
+* claims of official compatibility;
+* fake corporate provenance.
+
+## Useful simulated screens
+
+| Page | Purpose |
+| --- | --- |
+| 1000 | Master page index |
+| 105 | System status summary |
+| 110 | Switch environment |
+| 123 | Network overview |
+| 125 | Trunk summary |
+| 1800X | Processor/module status |
+| 1850 | Recent-change activity |
+| 1960 | Operator event display |

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -1,0 +1,37 @@
+# Web interface notes
+
+The web interface is planned as a second front end over the same simulator core.
+It should not replace the terminal craft shell.
+
+## Direction
+
+The web interface should feel like a 1990s internal web gateway to a craft
+terminal:
+
+* plain Perl CGI;
+* fixed-width terminal output;
+* HTML forms;
+* preformatted command output;
+* minimal CSS;
+* no modern application framework;
+* no heavy JavaScript;
+* simple session files;
+* shared simulator state and command dispatch.
+
+## Proposed layout
+
+    cgi-bin/5ess.cgi
+    htdocs/5ess.css
+    templates/
+    lib/FiveESS/CGI.pm
+
+## Required rules
+
+* Escape HTML output.
+* Avoid shelling out from request parameters.
+* Validate session ids.
+* Store session files under the configured state directory.
+* Document web-server write permissions.
+
+This is a future target. The first implementation should wait until command
+parsing and state handling are easier to test outside `5ESS.pl`.

--- a/t/alarms.t
+++ b/t/alarms.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib 'lib';
+require Persist;
+require Alarms;
+
+local $ENV{FIXED_TIME_FOR_TESTS} = '1996-02-15 03:04:05';
+
+my $state = Persist::default_state();
+my $alarms = Alarms->new($state);
+
+my $alarm = $alarms->raise_alarm(severity => 'MJ', source => 'PWR', text => 'BATTERY LOW');
+is($alarm->{id}, 1, 'first alarm id');
+is($alarm->{ack_state}, 'UNACK', 'alarm starts unacknowledged');
+is(scalar @{ $alarms->list_active() }, 1, 'one active alarm');
+
+$alarms->ack_alarm($alarm);
+is($alarm->{ack_state}, 'ACK', 'alarm can be acknowledged');
+
+$alarms->clear_alarm($alarm);
+is($alarm->{cleared_time}, '1996-02-15 03:04:05', 'alarm clear time uses fixed time');
+is(scalar @{ $alarms->list_active() }, 0, 'cleared alarm is not active');
+
+$alarms->ensure_alarm('DMERT', severity => 'MN', text => 'JOURNAL NEAR FULL');
+$alarms->ensure_alarm('DMERT', severity => 'MN', text => 'JOURNAL NEAR FULL');
+is(scalar @{ $alarms->list_active() }, 1, 'ensure_alarm does not duplicate active source');
+
+$alarms->clear_by_source('DMERT');
+is(scalar @{ $alarms->list_active() }, 0, 'clear_by_source clears active alarm');
+
+done_testing();

--- a/t/harness.t
+++ b/t/harness.t
@@ -1,0 +1,5 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+ok(1, 'harness runs');

--- a/t/persist.t
+++ b/t/persist.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+
+use lib 'lib';
+require Persist;
+
+my $dir = tempdir(CLEANUP => 1);
+local $ENV{5ESS_STATE_DIR} = $dir;
+local $ENV{FIXED_TIME_FOR_TESTS} = '1996-02-15 03:04:05';
+
+my $state = Persist::default_state();
+ok(ref $state eq 'HASH', 'default state is a hash');
+is($state->{rcaccess}{ttyV}, 'FFFFF', 'default ttyV access is full');
+
+Persist::append_journal({ type => 'test_event', value => 5 });
+ok(-e Persist::journal_path(), 'journal is created');
+
+my @events;
+Persist::replay_journal(sub { push @events, shift });
+is(scalar @events, 1, 'journal replays one event');
+is($events[0]{type}, 'test_event', 'event type survived replay');
+is($events[0]{_ts}, '1996-02-15 03:04:05', 'fixed time is used');
+
+Persist::save_snapshot($state, 'test');
+ok(-e Persist::snapshot_path(), 'snapshot is written');
+my $loaded = Persist::load_snapshot();
+ok(ref $loaded eq 'HASH', 'snapshot loads');
+
+done_testing();

--- a/t/rcv.t
+++ b/t/rcv.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib 'lib';
+require Persist;
+require RCV;
+
+local $ENV{FIXED_TIME_FOR_TESTS} = '1996-02-15 03:04:05';
+
+my $state = Persist::default_state();
+my $rcv = RCV->new($state, 'RCV_LOCAL');
+
+my ($ok, $msg) = $rcv->open_ticket('SO-1001');
+ok($ok, 'ticket opens');
+is($msg, 'TICKET OPENED', 'open message');
+
+($ok, $msg) = $rcv->open_ticket('SO-1002');
+ok(!$ok, 'second ticket is refused');
+
+($ok, $msg) = $rcv->add_change('TERM', '1001');
+ok($ok, 'term change staged');
+
+($ok, $msg) = $rcv->check_ticket($state->{lines});
+ok(!$ok, 'new line without required fields fails check');
+like($msg, qr/NEW LINE MISSING/, 'missing field details returned');
+
+for my $pair ([PAIR => '01-02-03'], [COS => 'POTS'], [LINETYPE => '1FR'], [CLASS => 'RES'], [DN => '5551001']) {
+    ($ok, $msg) = $rcv->add_change($pair->[0], $pair->[1]);
+    ok($ok, "staged $pair->[0]");
+}
+
+($ok, $msg) = $rcv->check_ticket($state->{lines});
+ok($ok, 'complete ticket passes check');
+
+my ($ticket, $payload, $changes);
+($ok, $msg, $ticket, $payload, $changes) = $rcv->commit_ticket($state->{lines}, $state->{dns});
+ok($ok, 'ticket commits');
+is($ticket, 'SO-1001', 'committed ticket id');
+is($state->{lines}{1001}{dn}, '5551001', 'line dn is assigned');
+is($state->{dns}{5551001}, '1001', 'dn index is assigned');
+
+($ok, $msg) = $rcv->abort_ticket();
+ok(!$ok, 'no ticket left to abort');
+
+($ok, $msg) = $rcv->open_ticket('SO-1003');
+ok($ok, 'second ticket opens after commit');
+($ok, $msg) = $rcv->abort_ticket();
+ok($ok, 'ticket aborts');
+
+done_testing();

--- a/t/rop.t
+++ b/t/rop.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+
+use lib 'lib';
+require ROP;
+
+my $dir = tempdir(CLEANUP => 1);
+local $ENV{FIXED_TIME_FOR_TESTS} = '1996-02-15 03:04:05';
+
+my $path = "$dir/rop.out";
+my $rop = ROP->new(
+    state_dir   => $dir,
+    path        => $path,
+    brand       => 'PACIFIC BELL',
+    office_id   => 'SF01',
+    switch_name => '5ESS-SF',
+);
+
+is($rop->path(), $path, 'ROP path is retained');
+
+$rop->log('RCV', 'INFO', 'RCV TEST RECORD');
+ok(-e $path, 'ROP output file is written');
+
+my $tail = $rop->tail(5);
+is(scalar @$tail, 1, 'tail returns one line');
+like($tail->[0], qr/PACIFIC BELL/, 'brand appears in ROP line');
+like($tail->[0], qr/RCV TEST RECORD/, 'message appears in ROP line');
+
+done_testing();

--- a/t/scc.t
+++ b/t/scc.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib 'lib';
+require Persist;
+require SCC;
+
+local $ENV{FIXED_TIME_FOR_TESTS} = '1996-02-15 03:04:05';
+
+my $state = Persist::default_state();
+my $scc = SCC->new($state);
+
+my $job = $scc->submit_job('CHECK', 'LINES');
+is($job->{id}, 1, 'first SCC job id');
+is($job->{status}, 'QUEUED', 'job starts queued');
+
+my $stats = $scc->stats();
+is($stats->{QUEUED}, 1, 'queued count');
+is($stats->{RUNNING}, 0, 'running count');
+
+$scc->tick();
+is($job->{status}, 'RUNNING', 'tick starts queued job');
+
+for (1 .. 5) {
+    $scc->tick();
+}
+
+is($job->{status}, 'DONE', 'job eventually completes');
+ok(grep(/COMPLETE/, @{ $job->{output} }), 'completion output recorded');
+
+$scc->log_event('SCC TEST MESSAGE');
+my @lines = $scc->emit_lines();
+ok(@lines <= 1, 'emit_lines returns zero or one line for one event');
+
+my $found = $scc->find_job(1);
+is($found->{name}, 'CHECK', 'find_job returns submitted job');
+
+done_testing();


### PR DESCRIPTION
Adds initial documentation, a MakeMaker test entry point, and Test::More coverage for the core simulator modules. Also records Pacific Bell theme notes and future web interface direction.